### PR TITLE
adds post install message

### DIFF
--- a/tcramer.gemspec
+++ b/tcramer.gemspec
@@ -21,4 +21,16 @@ Gem::Specification.new do |s|
 
   s.add_development_dependency "sqlite3"
   s.add_development_dependency "engine_cart"
+
+  s.post_install_message = %q{
+    tcramer is in the house!!!
+          🤠
+　　　　　🐧🐧🐧
+　　　　🐧 　🐧　🐧
+　　　👇🏽　  🐧🐧　👇🏽
+　　　　　🐧　  🐧
+　　　　　🐧　　🐧
+　　　　　 👢　　👢
+    howdy. I'm the sheriff of rake tasks.
+  }
 end


### PR DESCRIPTION
In the Sprint 1 demo, I noticed you used the phrase "tcramer is in the house" but we don't notify users that the gem is installed. This PR addresses that issue, and also adds a relevant sheriff emoji.