### PR TITLE
Generated rake task should do its work using a method rather than exposing its internal data structure

### DIFF
--- a/lib/generators/tcramer/install_generator.rb
+++ b/lib/generators/tcramer/install_generator.rb
@@ -14,7 +14,7 @@ module Tcramer
         %(
 desc 'Manage all the things'
 task :manage do
-  puts Tcramer::ISMS.sample
+  puts Tcramer.manage
 end
         )
       end

--- a/lib/tcramer.rb
+++ b/lib/tcramer.rb
@@ -2,6 +2,7 @@
 
 require 'tcramer/engine'
 
+# Tcramer writes rake tasks!
 module Tcramer
   ISMS = [
     'Why not?',
@@ -16,4 +17,8 @@ module Tcramer
     'Nailed it!',
     'Uh oh.'
   ].freeze
+
+  def self.manage
+    ISMS.sample
+  end
 end

--- a/spec/lib/tcramer_spec.rb
+++ b/spec/lib/tcramer_spec.rb
@@ -6,4 +6,10 @@ RSpec.describe Tcramer do
 
     it { is_expected.to be_a Array }
   end
+
+  describe '.manage' do
+    subject { described_class.manage }
+
+    it { is_expected.to be_in described_class::ISMS }
+  end
 end


### PR DESCRIPTION
This gives `Tcramer` an abstraction layer that provides flexibility to alter its operation without forcing difficult upgrades on downstream clients. It enables us to hold logic, such as conditionalization of Zalgo text, outside of the Rake task that is written. This will allow me to accommodate @barmintor's request on #10.